### PR TITLE
v1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v1.6.0
+## 06/20/2024
+
+1. []()
+    * For the "title" metadata, add option to append the site title to the page title.
+    * For "title" metadata, add option to specify the text that separates the page and site titles.
+    * Contributed by [Jorge Sepulveda (jorluiseptor@gmail.com)](https://github.com/jorluiseptor)
+
 # v1.5.0
 ## 01/04/2024
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ Here is the default configuration and an explanation of available options:
 
 ```yaml
 enabled: true # lets you turn the plugin off and on.
+title:
+  append_site_title: false # lets you turn the plugin off and on for the "title" metadata.
+  separator: '|' # text that separates the page title from the site title in the "title" metadata.
 description:
   enabled: true # lets you turn the plugin off and on for the "description" metadata.
   length: 30 # maximal number of words that will be used to fill the "description" metadata.
@@ -40,10 +43,6 @@ facebook:
 twitter:
   enabled: true # Lets you turn the plugin ON and OFF for the "Twitter Cards" metadata.
 ```
-
-  * The first `enabled` field lets you turn the plugin on and off.
-  * The `enabled` field in each metadata section lets you turn on and off the plugin for this metadata only.
-  * `length` is the maximal count of words that will be used to fill the corresponding metadata.
 
 If you need to change any value, then the best process is to copy the `autoseo.yaml` file into your `users/config/plugins/` folder (create it if it doesn't exist), and then modify there. This will override the default settings.
 

--- a/autoseo.php
+++ b/autoseo.php
@@ -66,6 +66,8 @@ class AutoSeoPlugin extends Plugin
     	$config = $this->mergeConfig($page);
     	if ( !$config['enabled']) return;
 
+        $appendSiteTitle =  $config['title.append_site_title'];
+        $siteTitleSeparator = $this->cleanString($config['title.separator']);
         $updateDescription =  $config['description.enabled'];
         $updatekeywords =  $config['keywords.enabled'];
         $updateFacebook =  $config['facebook.enabled'];
@@ -80,13 +82,30 @@ class AutoSeoPlugin extends Plugin
         $content = mb_substr(strip_tags($page->content()),0, 1000 );
 
         $cleanContent = $this->cleanText ($content, $config); // here because we don't want to make this call several times
-        $cleanTitle = $this->cleanString ($page->title()); // here because we don't want to make this call several times
+        $cleanTitle =  $this->getPageTitle($appendSiteTitle,$siteTitleSeparator); // here because we don't want to make this call several times
 
         if ($updateDescription) $meta = $this->getMetaDescription ($meta, $metaSite, $config, $cleanContent);
         if ($updatekeywords) $meta = $this->getMetaKeywords ($meta, $metaSite, $config);
         if ($updateFacebook) $meta = $this->getMetaOpenGraph ($meta, $metaSite, $config, $cleanContent, $cleanTitle);
         if ($updateTwitter) $meta = $this->getMetaTwitter ($meta, $metaSite, $config, $cleanContent, $cleanTitle);
         $page->metadata ($meta);
+    }
+
+    // PROCESS for the title metadata by concatenating the page title and the site title if enabled
+    private function getPageTitle($appendSiteTitle, $siteTitleSeparator) : string {
+        $page = $this->grav['page'];
+        $pageTitle = $this->cleanString ($page->title());
+        $titleMetadata = '';
+
+        if ($appendSiteTitle) {
+            $siteTitle = $this->config->get('site.title');
+            $titleMetadata = $pageTitle . ' ' . $siteTitleSeparator . ' ' . $siteTitle;
+        }
+        else {
+            $titleMetadata = $pageTitle;
+        }
+        
+        return $titleMetadata;
     }
 
     // PROCESS for the description metadata

--- a/autoseo.yaml
+++ b/autoseo.yaml
@@ -1,4 +1,7 @@
 enabled: true # lets you turn the plugin off and on.
+title:
+  append_site_title: false # lets you turn the plugin off and on for the "title" metadata.
+  separator: '|' # text that separates the page title from the site title in the "title" metadata.
 description:
   enabled: true # lets you turn the plugin off and on for the "description" metadata.
   length: 30 # maximal number of words that will be used to fill the "description" metadata.

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -1,5 +1,5 @@
 name: Auto SEO
-version: 1.5.0
+version: 1.6.0
 description: Grav AutoSEO is a plugin for Grav with which you can fill automatically the description and keywords metadata of a page using its content. It also adds Facebook Open Graph metadata and Twitter Cards Meta Tags.
 icon: magic
 author:
@@ -40,6 +40,25 @@ form:
       underline: 1
 
       fields:
+        title.append_site_title:
+          type: toggle
+          label: PLUGINS.AUTO_SEO.TITLE.APPEND_SITE_TITLE.LABEL
+          help: PLUGINS.AUTO_SEO.TITLE.APPEND_SITE_TITLE.HELP
+          highlight: 1
+          default: 0
+          options:
+            1: PLUGIN_ADMIN.ENABLED
+            0: PLUGIN_ADMIN.DISABLED
+          validate:
+            type: bool
+        title.separator:
+          type: text
+          label: PLUGINS.AUTO_SEO.TITLE.SEPARATOR.LABEL
+          help: PLUGINS.AUTO_SEO.TITLE.SEPARATOR.HELP
+          size: x-small
+          default: '|'
+          validate:
+            type: text
         description.enabled:
           type: toggle
           label: PLUGINS.AUTO_SEO.DESCRIPTION.ENABLED_LABEL

--- a/languages.yaml
+++ b/languages.yaml
@@ -6,6 +6,13 @@ en:
       PLUGIN_STATUS: Plugin status
       DEFAULT_CONFIG: Default values for the plugin configuration
       PLUGIN_DEPENDENCY_FAILED: Auto SEO Plugin failed to load. Composer dependencies not met.
+      TITLE:
+        APPEND_SITE_TITLE:
+          LABEL: Append the site title to the "title" meta 
+          HELP: Concatenates the site title to the "title" metadata, e.g., from 'About Us' to 'About Us | My Awesome Site'.
+        SEPARATOR:
+          LABEL: Separator text for "title" meta
+          HELP: Text that separates the page title from the site title in the "title" metadata, e.g., 'About Us | My Awesome Site' or 'About Us - My Awesome Site'.
       DESCRIPTION:
         ENABLED_LABEL: Auto fill for "description" meta
         ENABLED_HELP: Lets you turn the plugin ON and OFF for the "description" metadata only.
@@ -31,6 +38,13 @@ fr:
       PLUGIN_STATUS: Etat du plugin
       DEFAULT_CONFIG: Valeurs par défaut pour la configuration du plugin
       PLUGIN_DEPENDENCY_FAILED: le plug-in Auto SEO n'a pas pu être chargé. Les dépendances de Composer ne sont pas remplies.
+      TITLE:
+        APPEND_SITE_TITLE:
+          LABEL: Ajouter le titre du site à la méta "titre"
+          HELP: Concatène le titre du site aux métadonnées « titre », par exemple de « À propos de nous » à « À propos de nous | Mon site génial'.
+        SEPARATOR:
+          LABEL: Texte de séparation pour la méta "titre"
+          HELP: Texte qui sépare le titre de la page du titre du site dans les métadonnées « titre », par exemple « À propos de nous | Mon site génial » ou « À propos de nous – Mon site génial ».
       DESCRIPTION:
         ENABLED_LABEL: Remplissage automatique pour la méta "Description"
         ENABLED_HELP: Permet de mettre le plugin ON et OFF pour la métadonnée "Description" uniquement.


### PR DESCRIPTION
For the "title" metadata, add option to append the site title to the page title.

For "title" metadata, add option to specify the text that separates the page and site titles.